### PR TITLE
Fix K8 template path casing

### DIFF
--- a/basic/daemonset-with-service/daemonset.yaml.configami-template
+++ b/basic/daemonset-with-service/daemonset.yaml.configami-template
@@ -1,3 +1,3 @@
 {
-	"template": "k8/basic/daemonset"
+	"template": "K8/basic/daemonset"
 }

--- a/basic/daemonset-with-service/service.yaml.configami-template
+++ b/basic/daemonset-with-service/service.yaml.configami-template
@@ -1,3 +1,3 @@
 {
-	"template": "k8/basic/rancher-style-service"
+	"template": "K8/basic/rancher-style-service"
 }

--- a/basic/daemonset/daemonset.yaml.configami-template
+++ b/basic/daemonset/daemonset.yaml.configami-template
@@ -1,3 +1,3 @@
 {
-	"template": "k8/basic/deployment"
+	"template": "K8/basic/deployment"
 }

--- a/basic/deployment-with-service/deployment.yaml.configami-template
+++ b/basic/deployment-with-service/deployment.yaml.configami-template
@@ -1,3 +1,3 @@
 {
-	"template": "k8/basic/deployment"
+	"template": "K8/basic/deployment"
 }

--- a/basic/deployment-with-service/service.yaml.configami-template
+++ b/basic/deployment-with-service/service.yaml.configami-template
@@ -1,3 +1,3 @@
 {
-	"template": "k8/basic/rancher-style-service"
+	"template": "K8/basic/rancher-style-service"
 }

--- a/stack/gitlab-runner/01-gitlab-runner-node.yaml.configami-template
+++ b/stack/gitlab-runner/01-gitlab-runner-node.yaml.configami-template
@@ -1,3 +1,3 @@
 {
-	"template": "k8/workload/gitlab-runner-node"
+	"template": "K8/workload/gitlab-runner-node"
 }

--- a/stack/gitlab-runner/61-gitlab-runner-cleanup.yaml.configami-template
+++ b/stack/gitlab-runner/61-gitlab-runner-cleanup.yaml.configami-template
@@ -1,5 +1,5 @@
 {
-	"template": "k8/workload/gitlab-runner-cleanup",
+	"template": "K8/workload/gitlab-runner-cleanup",
 
 	"input": {
 		"name": "{{name}}-cleanup"

--- a/workload/deployment-with-fallback/template.configami.js
+++ b/workload/deployment-with-fallback/template.configami.js
@@ -10,7 +10,7 @@ module.exports = function(cg, input, output) {
 	//
 	// Setup namespace with labels
 	//
-	output["01-namespace.yaml"] = cg.applyTemplate( "k8/basic/namespace", { 
+	output["01-namespace.yaml"] = cg.applyTemplate( "K8/basic/namespace", {
 		"name"   : input.namespace,
 		"labels" : input["namespace-labels"] || null
 	})["namespace.yaml"];
@@ -19,7 +19,7 @@ module.exports = function(cg, input, output) {
 	// Setup ingress public-lb
 	//
 	if( input.ingress && input.ingress.host ) {
-		output["05-public-lb.yaml"] = cg.applyTemplate( "k8/basic/ingress", input.ingress )["ingress.yaml"];
+		output["05-public-lb.yaml"] = cg.applyTemplate( "K8/basic/ingress", input.ingress )["ingress.yaml"];
 	}
 
 	//
@@ -42,7 +42,7 @@ module.exports = function(cg, input, output) {
 	 */
 	function getDeploymentConfig(type) {
 		// Get baseline config
-		// Used in `k8/basic/deployment-with-service`
+			// Used in `K8/basic/deployment-with-service`
 		let ret = cg.joinNestedObject({}, simpleInput)
 		ret.name = input.name+"-"+type;
 
@@ -77,7 +77,7 @@ module.exports = function(cg, input, output) {
 	 * @return {String} to output as yaml
 	 */
 	function getServiceYaml(type) {
-		let subTemplateOutput = cg.applyTemplate("k8/basic/deployment-with-service", getDeploymentConfig(type), {});
+		let subTemplateOutput = cg.applyTemplate("K8/basic/deployment-with-service", getDeploymentConfig(type), {});
 		return subTemplateOutput["deployment.yaml"] + "\n" + subTemplateOutput["service.yaml"];
 	}
 

--- a/workload/gitlab-runner-cleanup/01-gitlab-runner-cleanup.yaml.configami-template
+++ b/workload/gitlab-runner-cleanup/01-gitlab-runner-cleanup.yaml.configami-template
@@ -1,5 +1,5 @@
 {
-	"template": "k8/basic/daemonset",
+	"template": "K8/basic/daemonset",
 	"input": {
 
 		// Name / Namespace

--- a/workload/gitlab-runner-node/03-gitlab-runner.yaml.configami-template
+++ b/workload/gitlab-runner-node/03-gitlab-runner.yaml.configami-template
@@ -1,5 +1,5 @@
 {
-	"template": "k8/basic/daemonset",
+	"template": "K8/basic/daemonset",
 	"input": {
 
 		// Name / Namespace

--- a/workload/glusterfs/01-namespace.yaml.configami-template
+++ b/workload/glusterfs/01-namespace.yaml.configami-template
@@ -1,5 +1,5 @@
 {
-	"template" : "k8/basic/namespace", 
+	"template" : "K8/basic/namespace",
 	"input": { 
 		"name"   : "{{namespace}}",
 	}

--- a/workload/glusterfs/02-daemonset.yaml.configami-template
+++ b/workload/glusterfs/02-daemonset.yaml.configami-template
@@ -1,3 +1,3 @@
 {
-	"template": "k8/basic/daemonset"
+	"template": "K8/basic/daemonset"
 }

--- a/workload/hazelcast/01-namespace.yaml.configami-template
+++ b/workload/hazelcast/01-namespace.yaml.configami-template
@@ -1,5 +1,5 @@
 {
-	"template" : "k8/basic/namespace", 
+	"template" : "K8/basic/namespace",
 	"input": { 
 		"name"   : "{{namespace}}",
 	}

--- a/workload/hazelcast/02-daemonset-with-service.yaml.configami-template
+++ b/workload/hazelcast/02-daemonset-with-service.yaml.configami-template
@@ -1,5 +1,5 @@
 {
-	"template": "k8/basic/daemonset-with-service",
+	"template": "K8/basic/daemonset-with-service",
 
 	"input_base": {
 


### PR DESCRIPTION
Summary:
Normalize internal K8 template references so configami resolves nested templates on case-sensitive filesystems.

Changes:
- Updated internal `k8/...` references to `K8/...` across the template repo.
- Keeps nested references aligned with the existing uppercase `K8` template directory used by platform-infra.
- Covers deployment, daemonset, service, workload, and stack wrapper templates so the first fix does not just reveal the next lowercase path failure.

Validation:
- Confirmed no lowercase `k8/` references remain.
- Ran `git diff --check` successfully.
- Parsed JSON-compatible changed template files.
- Ran a temp configami smoke test with this repo mounted as `TEMPLATE/K8`; generated deployment, daemonset, and service YAML successfully.
